### PR TITLE
APIプラグインとの競合回避

### DIFF
--- a/DependencyInjection/SocialLoginExtension.php
+++ b/DependencyInjection/SocialLoginExtension.php
@@ -48,6 +48,7 @@ class SocialLoginExtension extends EccubeExtension
         foreach($extensionConfigs["security"] as $key => $security) {
             if(isset($security["firewalls"])) {
                 $extensionConfigs["security"][$key]["firewalls"]["customer"]["guard"]["authenticators"][] = Auth0Authenticator::class;
+                $extensionConfigs["security"][$key]["firewalls"]["customer"]["guard"]["entry_point"] = Auth0Authenticator::class;
             }
         }
 


### PR DESCRIPTION
## 概要

APIプラグインがインストール済みの状態でインストールすると以下のエラーが発生する。

```
  [LogicException]
  Because you have multiple guard authenticators, you need to set the "guard.entry_point" key to one of your authenticators (Plugin\SocialLogin4\Security\Authenticator\Auth0Authenticator, Plugin\SocialLogin4\Security\Authenticator\Auth0Authenticator).
```
なぜか `Plugin\SocialLogin4\Security\Authenticator\Auth0Authenticator` が2つあると言われる。

## 方針
エラーメッセージとドキュメントに従って `guard.entry_point` を指定することでエラーを回避できました。
https://symfony.com/doc/3.4/security/multiple_guard_authenticators.html#multiple-authenticators-with-shared-entry-point

## 相談
APIプラグインの方も修正した方が良さそうな気がしますが、`Auth0Authenticator` でエラーになっていたのでこちらを修正してみました。